### PR TITLE
Update ETHGlobal year and add BlipMarkets to Proof of Work

### DIFF
--- a/components/Home/HackathonWins.tsx
+++ b/components/Home/HackathonWins.tsx
@@ -5,7 +5,7 @@ const hackathonWins = [
     award: "Finalist",
     description:
       "Built Blip Markets, a prediction market platform. Selected as a finalist at ETHGlobal.",
-    year: "2024",
+    year: "2026",
   },
   {
     title: "EthIndia 2024",

--- a/data/projectData.tsx
+++ b/data/projectData.tsx
@@ -8,6 +8,14 @@ export const projectData = [
     tags: ["PostgreSQL", "pgvector", "Ollama", "ETHGlobal"],
   },
   {
+    title: "BlipMarkets",
+    description:
+      "A deterministic, zero-sum prediction platform where users stake on discrete price-time cells overlaid on live ETH-USD price charts. Built with a Go backend, React + TypeScript frontend, PostgreSQL, Redis, and Solidity smart contracts on Base.",
+    image: "images/Blog/blip-markets/banner.png",
+    link: "https://github.com/virajbhartiya/blitmarkets",
+    tags: ["Go", "React", "PostgreSQL", "Solidity"],
+  },
+  {
     title: "Rail Infrastructure Optimization",
     description:
       "Built a rail infrastructure optimization algorithm focused on maximizing train throughput per track section.",


### PR DESCRIPTION
Changes:
- Update ETHGlobal Blip Markets achievement year from 2024 to 2026.

<img width="1155" height="281" alt="image" src="https://github.com/user-attachments/assets/29fd4648-80da-4e11-bff9-e2bb36f8b41e" />

- Add BlipMarkets as the second project in the Proof of Work section
  with description, tags, and GitHub link:
  https://github.com/virajbhartiya/blitmarkets

<img width="1699" height="749" alt="image" src="https://github.com/user-attachments/assets/64ae7bd0-02fe-4e39-be4d-9d38b22cf224" />

Notes:
- Only components/Home/HackathonWins.tsx and data/projectData.tsx are changed.
- Branches are able to merge with no conflicts.